### PR TITLE
add subnet linker

### DIFF
--- a/cmd/runetale/cmd/login.go
+++ b/cmd/runetale/cmd/login.go
@@ -71,13 +71,11 @@ func execLogin(ctx context.Context, args []string) error {
 		return nil
 	}
 
-	ip, cidr, err := loginNode(loginArgs.accessToken, c.NodePubKey, c.Spec.WgPrivateKey, c.ServerClient)
+	_, _, err = loginNode(loginArgs.accessToken, c.NodePubKey, c.Spec.WgPrivateKey, c.ServerClient)
 	if err != nil {
 		fmt.Printf("failed to login %s\n", err.Error())
 		return err
 	}
-
-	runelog.Logger.Infof("runetale ip => [%s/%s]", ip, cidr)
 
 	return nil
 }

--- a/daemon/daemon_darwin.go
+++ b/daemon/daemon_darwin.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -116,7 +115,7 @@ func (d *daemon) Install() (err error) {
 		return err
 	}
 
-	if err := ioutil.WriteFile(d.daemonFilePath, []byte(d.systemConfig), 0755); err != nil {
+	if err := os.WriteFile(d.daemonFilePath, []byte(d.systemConfig), 0755); err != nil {
 		d.runelog.Logger.Errorf("failed to write %s to %s. because %s\n", d.daemonFilePath, d.systemConfig, err.Error())
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/peterbourgon/ff/v2 v2.0.1
-	github.com/runetale/client-go v0.0.0-20240608080238-11788edfc888
+	github.com/runetale/client-go v0.0.0-20240612133501-5c5ce03282ca
 	go.uber.org/zap v1.21.0
 	go4.org/mem v0.0.0-20210711025021-927187094b94
 	golang.org/x/net v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,10 @@ github.com/runetale/client-go v0.0.0-20240608024952-8af0b95c740c h1:3KmThSztFb3X
 github.com/runetale/client-go v0.0.0-20240608024952-8af0b95c740c/go.mod h1:GGlN7nNAgzg2xwRZVv8i9GFpIfqAcnS72JMHb8Fw/0c=
 github.com/runetale/client-go v0.0.0-20240608080238-11788edfc888 h1:J/RbCr4Udx7iacMXHDVVQDtOfobG5U2sVRp3IcdvfYY=
 github.com/runetale/client-go v0.0.0-20240608080238-11788edfc888/go.mod h1:GGlN7nNAgzg2xwRZVv8i9GFpIfqAcnS72JMHb8Fw/0c=
+github.com/runetale/client-go v0.0.0-20240612080032-ded5d40bdc4e h1:xhsAAOq1HHtnjUhv2gK8iqKj3M2gC+9fvJUGt1nKcHE=
+github.com/runetale/client-go v0.0.0-20240612080032-ded5d40bdc4e/go.mod h1:GGlN7nNAgzg2xwRZVv8i9GFpIfqAcnS72JMHb8Fw/0c=
+github.com/runetale/client-go v0.0.0-20240612133501-5c5ce03282ca h1:qOjzflV/wK+BdvstBBQGgvYfQ62J8qx+U+znvJH+olE=
+github.com/runetale/client-go v0.0.0-20240612133501-5c5ce03282ca/go.mod h1:GGlN7nNAgzg2xwRZVv8i9GFpIfqAcnS72JMHb8Fw/0c=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/scripts/login.sh
+++ b/scripts/login.sh
@@ -4,4 +4,4 @@ sudo ./runetale login -signal-host=$SIGNAL_HOST \
     -server-host=$SERVER_HOST \
     -signal-port=$SIGNAL_PORT \
     -server-port=$SERVER_PORT \
-    -debug=$IS_DEBUG \
+    -debug=$IS_DEBUG


### PR DESCRIPTION
## What
- management iptables and ip route commands
- check daemon

## runetale iptablesを作る
新しいルーティングテーブルを追加
metricsは70、この処理を自動化

``` sh
echo "70 table8111" >> /etc/iproute2/rt_tables
```

## How it works Subnet Linker?

### 内部のサブネットネットワークのパケットをrt0を通るようにする設定
`iptables -t nat -A POSTROUTING -s 192.168.0.0/24 -o rt0 -j MASQUERADE`

内部ネットワーク（192.168.0.0/24）から外部ネットワークにパケットを送信する際に、この設定によりパケットの送信元IPアドレスが外部インターフェースのIPアドレスに変更される。これにより、外部ネットワークからは内部ネットワークの全てのマシンが外部インターフェースのIPアドレスから送信されているように見える。これがNAT（特にIPマスカレード）の基本的な動作

### 外部からのパケットを適切なサブネット空間にフォワーディングする。
`iptables -t nat -A PREROUTING -i rt0 -p tcp --dport 80 -j DNAT --to-destination 192.168.0.100:80`
aclのポートの番号に応じて、サブネット空間のポートにフォワーディングする。こうすることで、外部ネットワークからのアクセス時にrunetaleのsubnet linkerが適切なサブネットにパケットをフォワーディングする。

`iptables -t nat -A PREROUTING -i rt0 -p tcp --dport 80 -j DNAT --to-destination 192.168.0.100:80`
フォワーディングされたパケットを許可する

NATのMASQUERADEで内部のIPが露出することはない。
露出したいユースケースはあるか？MASQUEのON/OFFをする必要性について考える。 @hiroqn 

## How it works Universal Linker?
すべての通信をrt0を通るように強制ルーティングする機能、Different PRで実装

``` sh
#!/bin/bash

# IP転送を有効にする
echo 1 > /proc/sys/net/ipv4/ip_forward
sysctl -w net.ipv4.ip_forward=1

# NATマスカレード設定
iptables -t nat -A POSTROUTING -s 192.168.1.0/24 -o rt0 -j MASQUERADE

# ポリシールーティング設定
ip rule add from 192.168.1.0/24 table table8111
ip route add default via 100.100.19.1 dev rt0 table table8111
100.100.19.1はrt0のip addr
192.168.1.0/24は強制ルーティングされるサブネット空間である。

# 設定確認
ip rule show
ip route show table my_table
iptables -L -t nat
```
